### PR TITLE
Automatically change the calendar according to the year

### DIFF
--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -13,7 +13,7 @@ const Home: React.FC = () => {
           <p> Calendário Litúrgico </p>
         </Title>
 
-        <p>Ano 2020</p>
+        <p>Ano {new Date().getFullYear()}</p>
       </Header>
 
       <Container>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,7 +1,9 @@
 import axios from 'axios';
 
+const year = new Date().getFullYear()
+
 const api = axios.create({
-  baseURL: 'http://calapi.inadiutorium.cz/api/v0/en/calendars/default/2020',
+  baseURL: `http://calapi.inadiutorium.cz/api/v0/en/calendars/default/${year}`,
 });
 
 export default api;


### PR DESCRIPTION
Add the ability to automatically have the calendar of the current year use the `Date` object. Previously it was hardcoded to 2020.